### PR TITLE
[로또 - 클린 코드] 박진형 리팩터링

### DIFF
--- a/src/main/java/lotto/Application.java
+++ b/src/main/java/lotto/Application.java
@@ -1,14 +1,12 @@
 package lotto;
 
-import static lotto.domain.service.WinningStatistics.calculateResults;
-
 import java.util.List;
 import lotto.domain.generator.RandomLottoGenerator;
 import lotto.domain.model.Lotto;
-import lotto.domain.service.LottoMachine;
 import lotto.domain.model.Lottos;
 import lotto.domain.model.Money;
 import lotto.domain.model.WinningLotto;
+import lotto.domain.service.LottoMachine;
 import lotto.domain.service.WinningStatistics;
 import lotto.view.InputView;
 import lotto.view.OutputView;
@@ -36,7 +34,7 @@ public class Application {
         WinningLotto winningLotto = InputView.inputWinningLotto();
 
         WinningStatistics statistics = new WinningStatistics(purchaseAmount);
-        calculateResults(totalLottos, winningLotto, statistics);
+        statistics.calculateResults(totalLottos, winningLotto);
 
         OutputView.printResult(statistics);
     }

--- a/src/main/java/lotto/Application.java
+++ b/src/main/java/lotto/Application.java
@@ -14,29 +14,33 @@ import lotto.view.OutputView;
 public class Application {
 
     public static void main(String[] args) {
-        // 구입 금액 입력
         Money purchaseAmount = InputView.inputMoney();
 
-        int maxPossibleCount = purchaseAmount.calculateLottoCount();
-        int manualCount = InputView.inputManualCount(maxPossibleCount);
-
-        // 수동 구매
-        List<Lotto> manualLottos = InputView.inputManualLotto(manualCount);
-
-        LottoMachine lottoMachine = new LottoMachine(new RandomLottoGenerator());
-
-        Lottos totalLottos = lottoMachine.issueWithManual(maxPossibleCount, manualLottos);
-
-        int autoCount = maxPossibleCount - manualCount;
-        OutputView.print(manualCount, autoCount);
-        OutputView.printLottos(totalLottos);
+        Lottos totalLottos = issueAllLottos(purchaseAmount);
 
         WinningLotto winningLotto = InputView.inputWinningLotto();
-
-        WinningStatistics statistics = new WinningStatistics(purchaseAmount);
-        statistics.calculateResults(totalLottos, winningLotto);
+        WinningStatistics statistics = recordStatistics(purchaseAmount, totalLottos, winningLotto);
 
         OutputView.printResult(statistics);
+    }
+
+    private static Lottos issueAllLottos(Money money) {
+        int maxCount = money.calculateLottoCount();
+        int manualCount = InputView.inputManualCount(maxCount);
+        List<Lotto> manualLottos = InputView.inputManualLotto(manualCount);
+
+        Lottos totalLottos = new LottoMachine(new RandomLottoGenerator())
+            .issueWithManual(maxCount, manualLottos);
+
+        OutputView.print(manualCount, maxCount - manualCount);
+        OutputView.printLottos(totalLottos);
+        return totalLottos;
+    }
+
+    private static WinningStatistics recordStatistics(Money money, Lottos lottos, WinningLotto winningLotto) {
+        WinningStatistics statistics = new WinningStatistics(money);
+        statistics.calculateResults(lottos, winningLotto);
+        return statistics;
     }
 
 }

--- a/src/main/java/lotto/domain/model/Lotto.java
+++ b/src/main/java/lotto/domain/model/Lotto.java
@@ -28,6 +28,7 @@ public class Lotto {
     public boolean contains(LottoNumber number) {
         return lottoNumbers.contains(number);
     }
+
     public List<LottoNumber> getNumbers() {
         return lottoNumbers;
     }
@@ -36,16 +37,19 @@ public class Lotto {
         validateSize(lottoNumbers);
         validateDuplicate(lottoNumbers);
     }
+
     private static void validateSize(List<LottoNumber> lottoNumbers) {
         if (lottoNumbers.size() != LOTTO_SIZE) {
             throw new IllegalArgumentException("로또 번호는 6개여야 합니다.");
         }
     }
+
     private static void validateDuplicate(List<LottoNumber> rawNumbers) {
         if (rawNumbers.size() != new HashSet<>(rawNumbers).size()) {
             throw new IllegalArgumentException("로또 번호는 중복될 수 없습니다.");
         }
     }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/main/java/lotto/domain/model/Lotto.java
+++ b/src/main/java/lotto/domain/model/Lotto.java
@@ -16,7 +16,6 @@ public class Lotto {
     }
 
     private Lotto(List<LottoNumber> lottoNumbers) {
-        validateSize(lottoNumbers);
         this.lottoNumbers = lottoNumbers;
     }
 

--- a/src/main/java/lotto/domain/model/Lotto.java
+++ b/src/main/java/lotto/domain/model/Lotto.java
@@ -11,7 +11,7 @@ public class Lotto {
     private final List<LottoNumber> lottoNumbers;
 
     public static Lotto from(List<LottoNumber> numbers) {
-        validateDuplicate(numbers);
+        validate(numbers);
         return new Lotto(numbers);
     }
 
@@ -32,7 +32,12 @@ public class Lotto {
     public List<LottoNumber> getNumbers() {
         return lottoNumbers;
     }
-    private void validateSize(List<LottoNumber> lottoNumbers) {
+
+    private static void validate(List<LottoNumber> lottoNumbers) {
+        validateSize(lottoNumbers);
+        validateDuplicate(lottoNumbers);
+    }
+    private static void validateSize(List<LottoNumber> lottoNumbers) {
         if (lottoNumbers.size() != LOTTO_SIZE) {
             throw new IllegalArgumentException("로또 번호는 6개여야 합니다.");
         }

--- a/src/main/java/lotto/domain/model/Money.java
+++ b/src/main/java/lotto/domain/model/Money.java
@@ -41,7 +41,4 @@ public class Money {
             throw new IllegalArgumentException("금액은 1000원 이상부터 가능합니다.");
         }
     }
-
-
-
 }

--- a/src/main/java/lotto/domain/model/WinningLotto.java
+++ b/src/main/java/lotto/domain/model/WinningLotto.java
@@ -6,7 +6,7 @@ public class WinningLotto {
 
     private final LottoNumber bonusNumber;
 
-    public static WinningLotto from(Lotto winningLotto, LottoNumber bonusNumber) {
+    public static WinningLotto of(Lotto winningLotto, LottoNumber bonusNumber) {
         validate(winningLotto, bonusNumber);
         return new WinningLotto(winningLotto, bonusNumber);
     }

--- a/src/main/java/lotto/domain/model/WinningLotto.java
+++ b/src/main/java/lotto/domain/model/WinningLotto.java
@@ -12,7 +12,6 @@ public class WinningLotto {
     }
 
     private WinningLotto(Lotto winningLotto, LottoNumber bonusNumber) {
-        validate(winningLotto, bonusNumber);
         this.winningLotto = winningLotto;
         this.bonusNumber = bonusNumber;
     }

--- a/src/main/java/lotto/domain/parser/LottoParser.java
+++ b/src/main/java/lotto/domain/parser/LottoParser.java
@@ -5,9 +5,11 @@ import java.util.List;
 
 public class LottoParser {
 
+    private static final String NOT_NUMBER_ERROR = "숫자만 입력 가능합니다.";
+
     private LottoParser() {}
 
-    public static List<Integer> parseWinningNumbers(String string) {
+    public static List<Integer> parseNumbers(String string) {
         List<Integer> numbers = new ArrayList<>();
         try {
             String[] stringNumbers = string.split(",");
@@ -16,16 +18,16 @@ public class LottoParser {
                 numbers.add(number);
             }
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("당첨 번호는 숫자여야 합니다.");
+            throw new IllegalArgumentException(NOT_NUMBER_ERROR);
         }
         return numbers;
     }
 
-    public static int stringToInt(String string) {
+    public static int parseToInt(String string) {
         try {
             return Integer.parseInt(string);
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("당첨 번호는 숫자여야 합니다.");
+            throw new IllegalArgumentException(NOT_NUMBER_ERROR);
         }
     }
 }

--- a/src/main/java/lotto/domain/service/WinningStatistics.java
+++ b/src/main/java/lotto/domain/service/WinningStatistics.java
@@ -31,12 +31,12 @@ public class WinningStatistics {
     }
 
     public double calculateProfitRate() {
-        long totalPrize = 0;
-        for (LottoRank rank : statistics.keySet()) {
-            totalPrize += (long) rank.getPrizeMoney() * statistics.get(rank);
-        }
+        long totalPrize = statistics.entrySet().stream()
+            .mapToLong(entry -> (long) entry.getKey().getPrizeMoney() * entry.getValue())
+            .sum();
         return (double) totalPrize / purchaseMoney.getAmount();
     }
+
     private void initDefaultValues() {
         for (LottoRank rank : LottoRank.values()) {
             statistics.put(rank, 0);

--- a/src/main/java/lotto/domain/service/WinningStatistics.java
+++ b/src/main/java/lotto/domain/service/WinningStatistics.java
@@ -19,18 +19,14 @@ public class WinningStatistics {
         this.purchaseMoney = purchaseMoney;
     }
 
-    public void addResult(LottoRank rank) {
-        this.statistics.put(rank,  this.statistics.get(rank) + 1);
-    }
-
     public int getCount(LottoRank rank) {
         return statistics.get(rank);
     }
 
-    public static void calculateResults(Lottos lottos, WinningLotto winningLotto, WinningStatistics statistics) {
+    public void calculateResults(Lottos lottos, WinningLotto winningLotto) {
         lottos.getValues().forEach(lotto -> {
             LottoRank rank = winningLotto.judge(lotto);
-            statistics.addResult(rank);
+            addResult(rank);
         });
     }
 
@@ -45,5 +41,9 @@ public class WinningStatistics {
         for (LottoRank rank : LottoRank.values()) {
             statistics.put(rank, 0);
         }
+    }
+
+    private void addResult(LottoRank rank) {
+        this.statistics.put(rank,  this.statistics.get(rank) + 1);
     }
 }

--- a/src/main/java/lotto/view/InputView.java
+++ b/src/main/java/lotto/view/InputView.java
@@ -37,7 +37,7 @@ public class InputView {
     public static int inputManualCount(int maxCount) {
         return input("수동으로 구매할 로또 수를 입력해 주세요.", () -> {
             String input = sc.nextLine();
-            int count = LottoParser.stringToInt(input);
+            int count = LottoParser.parseToInt(input);
 
             if (count < 0 || count > maxCount) {
                 throw new IllegalArgumentException("수동 구매 수는 0에서 " + maxCount + " 사이여야 합니다.");
@@ -47,35 +47,32 @@ public class InputView {
     }
 
     public static List<Lotto> inputManualLotto(int manualCount) {
-        return input("수동으로 구매할 번호를 입력해 주세요.", () -> {
-            List<Lotto> manualLottos = new ArrayList<>();
-                for (int i = 0; i < manualCount; i++) {
-                    String line = sc.nextLine();
-                    List<Integer> rawNumbers = LottoParser.parseWinningNumbers(line);
+        System.out.println("수동으로 구매할 번호를 입력해 주세요.");
+        List<Lotto> lottos = new ArrayList<>();
+        for (int i = 0; i < manualCount; i++) {
+            lottos.add(inputSingleManualLotto()); // 한 줄씩 재입력 받기
+        }
+        return lottos;
+    }
 
-                    List<LottoNumber> lottoNumbers = rawNumbers.stream()
-                        .map(LottoNumber::valueOf)
-                        .toList();
-
-                    manualLottos.add(Lotto.from(lottoNumbers));
-                }
-                return manualLottos;
-            }
-        );
+    private static Lotto inputSingleManualLotto() {
+        return input("", InputView::readLotto);
     }
 
     public static WinningLotto inputWinningLotto() {
-        Lotto winningNumbers = input("지난 주 당첨 번호를 입력해주세요.", () -> {
-            List<Integer> rawNumbers = LottoParser.parseWinningNumbers(sc.nextLine());
-            List<LottoNumber> lottoNumbers = rawNumbers.stream()
-                .map(LottoNumber::valueOf)
-                .toList();
-            return Lotto.from(lottoNumbers);
-        });
+        Lotto winningNumbers = input("지난 주 당첨 번호를 입력해주세요.", InputView::readLotto);
 
         return input("보너스 볼을 입력해주세요", () -> {
-            LottoNumber bonusNumber = LottoNumber.valueOf(LottoParser.stringToInt(sc.nextLine()));
-            return WinningLotto.of(winningNumbers, bonusNumber); // 생성자에서 중복 검사!
+            LottoNumber bonusNumber = LottoNumber.valueOf(LottoParser.parseToInt(sc.nextLine()));
+            return WinningLotto.of(winningNumbers, bonusNumber);
         });
+    }
+
+    private static Lotto readLotto() {
+        List<Integer> rawNumbers = LottoParser.parseNumbers(sc.nextLine());
+        List<LottoNumber> lottoNumbers = rawNumbers.stream()
+            .map(LottoNumber::valueOf)
+            .toList();
+        return Lotto.from(lottoNumbers);
     }
 }

--- a/src/main/java/lotto/view/InputView.java
+++ b/src/main/java/lotto/view/InputView.java
@@ -75,7 +75,7 @@ public class InputView {
 
         return input("보너스 볼을 입력해주세요", () -> {
             LottoNumber bonusNumber = LottoNumber.valueOf(LottoParser.stringToInt(sc.nextLine()));
-            return WinningLotto.from(winningNumbers, bonusNumber); // 생성자에서 중복 검사!
+            return WinningLotto.of(winningNumbers, bonusNumber); // 생성자에서 중복 검사!
         });
     }
 }

--- a/src/test/java/lotto/model/WinningLottoTest.java
+++ b/src/test/java/lotto/model/WinningLottoTest.java
@@ -22,7 +22,7 @@ public class WinningLottoTest {
         LottoNumber bonusNumber = LottoNumber.valueOf(1); // 중복된 번호
 
         // when & then
-        assertThatThrownBy(() -> WinningLotto.from(winningNumbers, bonusNumber))
+        assertThatThrownBy(() -> WinningLotto.of(winningNumbers, bonusNumber))
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("보너스 볼 번호는 기존 로또 번호와 중복될 수 없습니다.");
     }
@@ -33,7 +33,7 @@ public class WinningLottoTest {
         // given
         Lotto winningNumbers = Lotto.from(createLottoNumbers(1, 2, 3, 4, 5, 6));
         LottoNumber bonusNumber = LottoNumber.valueOf(7);
-        WinningLotto winningLotto = WinningLotto.from(winningNumbers, bonusNumber);
+        WinningLotto winningLotto = WinningLotto.of(winningNumbers, bonusNumber);
 
         Lotto playerLotto = Lotto.from(createLottoNumbers(1, 2, 3, 4, 5, 7)); // 5개 일치 + 보너스 일치
 


### PR DESCRIPTION
## 로또 리팩터링
--- 
### 검증 메서드를 정적 팩터리 메서드에 통합
- 기존에는 로또의 사이즈와 중복에 대한 검증이 생성자와 정적 팩터리 메서드에 분산되어 있었음
- validate 메서드에 validateSize와 validateDuplicate를 담아 정적 팩터리 메서드에서만 호출하여 캡슐화
- Lotto.from()에서 검증을 수행하여, 외부에서는 유효한 로또 객체만 받을 수 있도록 보

### WinningStatistics 객체지향적 설계 개선
- calculateResults()가 기존에 파라미터로 WinningStatistics를 직접 가지던 것을 없애고, 인스턴스 메서드로 변경하여 객체 내부의 statistics 필드를 직접 업데이트하도록 개선 
- 이 과정에서 addResult()와 같은 상태 변경 메서드를 private으로 캡슐화하여, 외부에서 통계 데이터를 임의로 조작할 수 없도록 데이터 무결성을 보장
- `WinningStatistics statistics = new WinningStatistics(purchaseAmount);`
- `statistics.calculateResults(totalLottos, winningLotto);`

### 메서드 분리 및 10라인 제한 준수
- Application의 main 메서드에 집중되어 있던 로직을 issueAllLottos, recordStatistics 등 의미 있는 단위의 메서드로 분리
- InputView에서 로또 번호를 읽어 객체로 만드는 반복적인 로직을 readLotto() 메서드로 공통화하여 가독성 향상

### 에러 처리 개선
- LottoParser에서 일괄적으로 "당첨 번호..."라고 출력되던 에러 메시지를 "숫자만 입력 가능합니다."와 같은 범용적인 메시지로 수정
- 수동 로또를 여러 장 입력하는 과정에서 예외가 발생할 경우, 전체 리스트를 처음부터 다시 입력하는 것이 아니라 문제가 발생한 해당 줄만 다시 입력받도록 로직을 정교화